### PR TITLE
fix: enforce minimum wakatime-cli version and remove unsupported --ai-line-changes flag

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,31 @@ import AdmZip from 'adm-zip';
 const GITHUB_RELEASES_URL = 'https://api.github.com/repos/wakatime/wakatime-cli/releases/latest';
 const GITHUB_DOWNLOAD_URL = 'https://github.com/wakatime/wakatime-cli/releases/latest/download';
 
+// Minimum version required to support the "ai coding" category (added in v1.118.0).
+// Any binary older than this will be replaced with the latest download.
+const MIN_VERSION = [1, 118, 0];
+
+/**
+ * Parse a wakatime-cli version string like "v1.118.0" into [major, minor, patch].
+ * Returns null if the string cannot be parsed.
+ */
+function parseVersion(raw: string): [number, number, number] | null {
+  const match = raw.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [parseInt(match[1], 10), parseInt(match[2], 10), parseInt(match[3], 10)];
+}
+
+/**
+ * Returns true if `version` satisfies the minimum version requirement.
+ */
+function meetsMinimum(version: [number, number, number]): boolean {
+  for (let i = 0; i < 3; i++) {
+    if (version[i] > MIN_VERSION[i]) return true;
+    if (version[i] < MIN_VERSION[i]) return false;
+  }
+  return true; // equal
+}
+
 export class WakaTimeCli {
   private cliLocation: string | undefined;
   private installDir: string;
@@ -60,15 +85,46 @@ export class WakaTimeCli {
     return standardPath;
   }
 
+  /**
+   * Returns the version string reported by the binary at `location`,
+   * or null if it cannot be determined.
+   */
+  private getInstalledVersion(location: string): string | null {
+    try {
+      return child_process.execSync(`"${location}" --version`, { timeout: 5000 }).toString().trim();
+    } catch (e) {
+      return null;
+    }
+  }
+
   public async checkAndInstall(): Promise<string> {
     const location = this.getLocation();
-    if (fs.existsSync(location)) {
-      return location;
+
+    if (!fs.existsSync(location)) {
+      console.log('[WakaTime] Installing wakatime-cli...');
+      await this.install();
+      return this.getLocation();
     }
 
-    console.log('[WakaTime] Installing wakatime-cli...');
-    await this.install();
-    return this.getLocation();
+    // Binary exists — check its version meets the minimum requirement.
+    const raw = this.getInstalledVersion(location);
+    const version = raw ? parseVersion(raw) : null;
+
+    if (!version) {
+      console.log(`[WakaTime] Could not determine version of ${location}, re-installing...`);
+      await this.install();
+      return this.getLocation();
+    }
+
+    if (!meetsMinimum(version)) {
+      console.log(
+        `[WakaTime] wakatime-cli ${raw} is below minimum required v${MIN_VERSION.join('.')} — updating...`
+      );
+      await this.install();
+      return this.getLocation();
+    }
+
+    return location;
   }
 
   private async install(): Promise<void> {
@@ -100,7 +156,8 @@ export class WakaTimeCli {
         fs.chmodSync(targetPath, 0o755);
     }
     
-    this.cliLocation = targetPath;
+    // Clear cached location so getLocation() re-evaluates after install
+    this.cliLocation = undefined;
     console.log(`[WakaTime] Installed to ${targetPath}`);
   }
 

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -78,10 +78,7 @@ export class HeartbeatSender {
       args.push('--write');
     }
 
-    if (params.lineChanges !== undefined) {
-      args.push('--category', 'ai coding');
-      args.push('--ai-line-changes', params.lineChanges.toString());
-    }
+    // Note: --ai-line-changes is not supported by wakatime-cli; category is already set above.
 
     // Run in background, don't await
     child_process.execFile(cliPath, args, (error, stdout, stderr) => {


### PR DESCRIPTION
### Problem

Two bugs cause heartbeats to silently fail when an older `wakatime-cli` binary is present on the system.

**1. `--ai-line-changes` flag does not exist in wakatime-cli**

When `lineChanges` is provided to `HeartbeatSender.send()`, `heartbeat.ts` passes `--ai-line-changes` to the CLI. This flag has never been part of `wakatime-cli`’s public interface — it causes the process to exit with an error and print its full help text instead of sending the heartbeat.

Additionally, `--category ai coding` was being pushed a second time inside the same block, duplicating the flag already set at the top of `args`.

**2. No minimum version check allows stale system binaries to break silently**

`checkAndInstall()` only downloads `wakatime-cli` if the binary is *missing*. If an older binary is already present — from a system package manager, a previous install, or another editor’s extension — it is used as-is without any version validation.

This is the same class of problem described in [wakatime/zed-wakatime#13](https://github.com/wakatime/zed-wakatime/issues/13). The zed-wakatime maintainers could not fix it due to Zed’s extension API limitations. `pi-wakatime` runs in plain Node.js and has no such constraint.

Concretely: `"ai coding"` was added as a valid heartbeat category in [`wakatime-cli` v1.118.0](https://github.com/wakatime/wakatime-cli/releases/tag/v1.118.0) (released 2025-07-14). Any binary older than that rejects the category value and drops every heartbeat sent by this plugin.

---

### Fix

**`src/heartbeat.ts`**

Remove the `--ai-line-changes` push and the duplicate `--category` push from the `lineChanges` block. The category is already correctly set earlier in `args` from `params.category`.

**`src/cli.ts`**

Add a minimum version check to `checkAndInstall()`. After locating an existing binary, its version is read via `--version` and compared against `MIN_VERSION = [1, 118, 0]`. If the binary is older than the minimum, or its version cannot be parsed, the latest release is downloaded to `~/.wakatime/wakatime-cli` — exactly as during a fresh install.

Also resets `this.cliLocation` to `undefined` at the end of `install()`, so `getLocation()` re-evaluates the path correctly after a re-install rather than returning the now-replaced cached path.

---

### Testing

Verified locally by temporarily using v1.115.2 (a version that predates `"ai coding"`) and confirming the version check triggers a re-download. After the update, heartbeats with `--category "ai coding"` send successfully (exit 0).